### PR TITLE
Add material ui icon

### DIFF
--- a/src/common/techstack/TechStackInfo.js
+++ b/src/common/techstack/TechStackInfo.js
@@ -2,7 +2,7 @@ import {
   SiReact,
   SiRedux,
   SiGit,
-  // SiMaterialui,
+  SiMui,
   SiTailwindcss,
   SiJavascript,
   SiFirebase,
@@ -42,12 +42,12 @@ export const TechStackInfo = [
     type: 'icon',
     link: 'https://git-scm.com'
   },
-  // {
-  //   comp: SiMaterialui,
-  //   text: 'Material UI',
-  //   type: 'icon',
-  //   link: 'https://mui.com'
-  // },
+  {
+    comp: SiMaterialui,
+    text: 'Material UI',
+    type: 'icon',
+    link: 'https://mui.com'
+  },
   {
     comp: SiTailwindcss,
     text: 'Tailwind',


### PR DESCRIPTION
The name of material ui icon imported from react-icons/si was wrong. I updated to the correct name.

> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
